### PR TITLE
言語コードが入るURLをマッチさせたく、matchesに追加

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
     {
       "js": ["scripts/content.js"],
       "matches": [
-        "https://atnd.ak4.jp/attendance"
+        "https://atnd.ak4.jp/attendance",
+        "https://atnd.ak4.jp/*/attendance"
       ]
     }
   ]


### PR DESCRIPTION
@akht AKASHIのサイドバーから出勤簿を開くとき、
https://atnd.ak4.jp/ja/attendance
のように、言語コードが入ることがあったのでその場合でも拡張が動くように `manifest.json` を修正しました。

10行目なくてもイケるかと思ったけど、イケませんでした。よろしくお願いします。